### PR TITLE
Use correct inline code block in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 django-fastdev
 ==============
 
-Django-fastdev is an app that makes it faster and more fun to develop Django apps.
+:code:`django-fastdev` is an app that makes it faster and more fun to develop Django apps.
 
 Features
 --------
@@ -34,7 +34,7 @@ instead of rendering that as an empty string, this app will give you an error me
         request
         user
 
-There are more specialized error messages for when you try to access the contents of a `dict`, and attributes of an object a few levels deep like `foo.bar.baz` (where baz doesn't exist).
+There are more specialized error messages for when you try to access the contents of a :code:`dict`, and attributes of an object a few levels deep like :code:`foo.bar.baz` (where baz doesn't exist).
 
 NoReverseMatch errors
 ~~~~~~~~~~~~~~~~~~~~~
@@ -46,10 +46,10 @@ Have you ever gotten this error?
     django.urls.exceptions.NoReverseMatch: Reverse for 'view-name' with arguments '('',)' not found. 1 pattern(s) tried:
 
 
-it's because you have `{% url 'view-name' does_not_exist %}`. Django sees
-`does_not_exist` and evaluates it to the empty string because it doesn't exist.
-So that's why you get an error message that makes no sense. Django-fastdev will
-make your code crash on the actual error: `does_not_exist` doesn't exist.
+It's because you have :code:`{% url 'view-name' does_not_exist %}`. Django sees
+:code:`does_not_exist` and evaluates it to the empty string because it doesn't exist.
+So that's why you get an error message that makes no sense. :code:`django-fastdev` will
+make your code crash on the actual error: :code:`does_not_exist` doesn't exist.
 
 
 Error if you have non-space text outside a block when extending
@@ -64,10 +64,10 @@ A common mistake for beginners that can be hard to spot is when they do:
         stuff here
     </html>
 
-Django silently throws away `stuff here` and `</html>`. `Django-fastdev` makes this an error.
+Django silently throws away :code:`stuff here` and :code:`</html>`. :code:`django-fastdev` makes this an error.
 
 
-Error on invalid block names when using `{% extends "..." %}`
+Error on invalid block names when using :code:`{% extends "..." %}`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you have a base template:
@@ -91,22 +91,22 @@ and then write a template like this:
     {% endblock %}
 
 
-Django will silently throw away `hello!` because you wrote `contents` instead
-of `content`. `Django-fastdev` will turn this into an error which lists the
+Django will silently throw away `hello!` because you wrote :code:`contents` instead
+of :code:`content`. :code:`django-fastdev` will turn this into an error which lists the
 invalid and valid block names in alphabetical order.
 
 Better error messages for reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The standard error message for a bad `reverse()`/`{% url %}` are rather sparse.
-`Django-fastdev` improves them by listing valid patterns so you can easily see
+The standard error message for a bad :code:`reverse()/{% url %}` are rather sparse.
+:code:`django-fastdev` improves them by listing valid patterns so you can easily see
 the problem.
 
 
 Better error messages for QuerySet.get()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The error message for `QuerySet.get()` is improved to give you the query
+The error message for :code:`QuerySet.get()` is improved to give you the query
 parameters that resulted in the exception.
 
 
@@ -114,17 +114,17 @@ Validate clean_* methods
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 A common mistake is to make a form clean method and make a spelling error. By
-default Django just won't call the function. With `django-fastdev` you will get
+default Django just won't call the function. With :code:`django-fastdev` you will get
 an error message telling you that your clean method doesn't match anything.
 
 This is also very useful during refactoring. Renaming a field is a lot safer
-as if you forget to rename the clean method `django-fastdev` will tell you!
+as if you forget to rename the clean method :code:`django-fastdev` will tell you!
 
 
 Faster startup
 ~~~~~~~~~~~~~~
 
-The initial model checks can be quite slow on big projects. `Django-fastdev`
+The initial model checks can be quite slow on big projects. :code:`django-fastdev`
 will move these checks to a separate thread, so the runserver startup time is
 lowered, so you don't have to wait for the runserver restart as long.
 
@@ -132,9 +132,9 @@ lowered, so you don't have to wait for the runserver restart as long.
 Usage
 ------
 
-First install: `pip install django-fastdev`
+First install: :code:`pip install django-fastdev`
 
-In `settings.py` add `django_fastdev` to INSTALLED_APPS:
+In :code:`settings.py` add :code:`django_fastdev` to INSTALLED_APPS:
 
 .. code:: python
 


### PR DESCRIPTION
Since Readme is using `.rst` we need to use `:code:` blocks to highlight inline code blocks. 