### PR TITLE
change: templates outside of project directory are ignored

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+1.7.3
+~~~~~
+
+* Changed: only HTML templates within your main project directory are checked; HTML templates outside of your main project directory revert to standard django behavior
+
+
 1.7.2
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,9 @@ instead of rendering that as an empty string, this app will give you an error me
 
 There are more specialized error messages for when you try to access the contents of a :code:`dict`, and attributes of an object a few levels deep like :code:`foo.bar.baz` (where baz doesn't exist).
 
+By default, :code:`django-fastdev` only checks templates that exist within your project directory. If you want it to check ALL templates, including stock django templates and templates from third party libraries, add :code:`FASTDEV_STRICT_TEMPLATE_CHECKING = True` to your project :code:`settings.py`.
+
+
 NoReverseMatch errors
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/django_fastdev/__init__.py
+++ b/django_fastdev/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.7.4'
+__version__ = '1.7.3'
 
 from threading import Thread
 from time import sleep

--- a/django_fastdev/__init__.py
+++ b/django_fastdev/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.7.3'
+__version__ = '1.7.4'
 
 from threading import Thread
 from time import sleep

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -201,8 +201,10 @@ class FastDevConfig(AppConfig):
                         venv_dir = os.environ.get('VIRTUAL_ENV', '')
                         if (
                             'django-fastdev/tests/' not in str(context.template.origin)
-                            and not str(context.template.origin).startswith(str(settings.BASE_DIR))
-                            and not (venv_dir and str(context.template.origin).startswith(venv_dir))
+                            and (
+                                not str(context.template.origin).startswith(str(settings.BASE_DIR))
+                                or (venv_dir and str(context.template.origin).startswith(venv_dir))
+                            )
                         ):
                             return orig_resolve(self, context, ignore_failures=ignore_failures)
                     if ignore_failures_for_real or getattr(_local, 'ignore_errors', False):

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -168,6 +168,10 @@ def strict_if():
     return getattr(settings, 'FASTDEV_STRICT_IF', False)
 
 
+def strict_template_checking():
+    return getattr(settings, 'FASTDEV_STRICT_TEMPLATE_CHECKING', False)
+
+
 def get_venv_folder_name():
     import os
 
@@ -191,13 +195,14 @@ class FastDevConfig(AppConfig):
                 except FastDevVariableDoesNotExist:
                     raise
                 except VariableDoesNotExist as e:
-                    # worry only about templates inside our project dir; if they  
-                    # exist elsewhere, then go to standard django behavior
-                    if (
-                        'django-fastdev/tests/' not in str(context.template.origin)
-                        and not str(context.template.origin).startswith(str(settings.BASE_DIR))
-                    ):
-                        return orig_resolve(self, context, ignore_failures=ignore_failures)
+                    if not strict_template_checking():
+                        # worry only about templates inside our project dir; if they  
+                        # exist elsewhere, then go to standard django behavior
+                        if (
+                            'django-fastdev/tests/' not in str(context.template.origin)
+                            and not str(context.template.origin).startswith(str(settings.BASE_DIR))
+                        ):
+                            return orig_resolve(self, context, ignore_failures=ignore_failures)
                     if ignore_failures_for_real or getattr(_local, 'ignore_errors', False):
                         if _local.deprecation_warning:
                             warnings.warn(_local.deprecation_warning, category=DeprecationWarning)

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -198,9 +198,11 @@ class FastDevConfig(AppConfig):
                     if not strict_template_checking():
                         # worry only about templates inside our project dir; if they  
                         # exist elsewhere, then go to standard django behavior
+                        venv_dir = os.environ.get('VIRTUAL_ENV', '')
                         if (
                             'django-fastdev/tests/' not in str(context.template.origin)
                             and not str(context.template.origin).startswith(str(settings.BASE_DIR))
+                            and not (venv_dir and str(context.template.origin).startswith(venv_dir))
                         ):
                             return orig_resolve(self, context, ignore_failures=ignore_failures)
                     if ignore_failures_for_real or getattr(_local, 'ignore_errors', False):

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -191,6 +191,13 @@ class FastDevConfig(AppConfig):
                 except FastDevVariableDoesNotExist:
                     raise
                 except VariableDoesNotExist as e:
+                    # worry only about templates inside our project dir; if they  
+                    # exist elsewhere, then go to standard django behavior
+                    if (
+                        'django-fastdev/tests/' not in str(context.template.origin)
+                        and not str(context.template.origin).startswith(str(settings.BASE_DIR))
+                    ):
+                        return orig_resolve(self, context, ignore_failures=ignore_failures)
                     if ignore_failures_for_real or getattr(_local, 'ignore_errors', False):
                         if _local.deprecation_warning:
                             warnings.warn(_local.deprecation_warning, category=DeprecationWarning)


### PR DESCRIPTION
I love django-fastdev, but I think myself and many other devs have had a hassle with it flagging external templates. I wrote a small bit of code that will defer to django the error handling for templates outside of the base project directory. Should help a lot with third party django libraries which are noncompliant with how fastdev handles things.