### PR TITLE
Check if virtualenv ENV is set

### DIFF
--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -81,16 +81,18 @@ def check_for_pycache_in_gitignore(line):
 
 def validate_gitignore(path):
     project_path = get_path_for_django_project()
-    try:
-        venv_directory = Path(os.environ['VIRTUAL_ENV']).resolve(strict=True)
+    venv_directory_parts = tuple()
+    if 'VIRTUAL_ENV' in os.environ:
         try:
-            venv_directory_parts = venv_directory.relative_to(project_path).parts
-        except ValueError:
-            # venv is not in project directory
-            venv_directory_parts = tuple()
-    except KeyError:
-        print("Please activate your virtual environment before running this command.")
-        return
+            venv_directory = Path(os.environ['VIRTUAL_ENV']).resolve(strict=True)
+            try:
+                venv_directory_parts = venv_directory.relative_to(project_path).parts
+            except ValueError:
+                # venv is not in project directory
+                venv_directory_parts = tuple()
+        except KeyError:
+            print("Gitignore validation: Please activate your virtual environment before running this command.")
+            return
 
     bad_line_numbers_for_ignoring_migration = []
     list_of_subfolders = [f.name for f in os.scandir(project_path) if f.is_dir()]


### PR DESCRIPTION
As you can see from the screenshot that alert can be executed also in other context but is wrong (I am using poetry and the .venv folder exists).
This tiny patch check if the ENV variable is set, sure can be improved but atleast in my case I don't get that alert anyway.

![Screenshot_20240223_154840](https://github.com/boxed/django-fastdev/assets/403283/d5e21f8b-20ec-4dec-b380-b9c839cd2153)
