### PR TITLE
Improve the reliability of venv gitignore checking

### DIFF
--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -1,6 +1,7 @@
 import inspect
 import os
 import re
+import sys
 import threading
 import warnings
 from contextlib import (
@@ -92,7 +93,7 @@ def validate_gitignore(path):
                 # venv is not in project directory
                 venv_directory_parts = tuple()
         except KeyError:
-            print("Gitignore validation: Please activate your virtual environment before running this command.")
+            print("Gitignore validation: Please activate your virtual environment before running this command.", file=sys.stderr)
             return
 
     bad_line_numbers_for_ignoring_migration = []
@@ -120,19 +121,19 @@ def validate_gitignore(path):
 
             https://docs.djangoproject.com/en/dev/topics/migrations/#version-control for more information
 
-            Bad pattern on lines : {', '.join(map(str, bad_line_numbers_for_ignoring_migration))}""")
+            Bad pattern on lines : {', '.join(map(str, bad_line_numbers_for_ignoring_migration))}""", file=sys.stderr)
 
         if not is_venv_ignored:
             print(f"""
             {venv_directory_parts[0]} is not ignored in .gitignore.
             Please add {venv_directory_parts[0]} to .gitignore.
-            """)
+            """, file=sys.stderr)
 
         if not is_pycache_ignored and "__pycache__" in list_of_subfolders:
             print(f"""
             __pycache__ is not ignored in .gitignore.
             Please add __pycache__ to .gitignore.
-            """)
+            """, file=sys.stderr)
 
 
 def validate_fk_field(model):
@@ -165,7 +166,8 @@ def get_models_with_badly_named_pk():
         This is wrong. The Django ForeignKey is a relation to a model object, not it's ID, so this is correct:
             car = ForeignKey(Car)
 
-        Django will create a `car_id` field under the hood that is the ID of that field (normally a number)."""
+        Django will create a `car_id` field under the hood that is the ID of that field (normally a number).""",
+            file=sys.stderr
         )
 
 

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,4 +1,8 @@
-from django_fastdev.apps import FastDevVariableDoesNotExist, check_for_migrations_in_gitignore, check_for_pycache_in_gitignore, check_for_venv_in_gitignore
+import subprocess
+import pytest
+from pathlib import Path
+import sys
+from django_fastdev.apps import FastDevVariableDoesNotExist, check_for_migrations_in_gitignore, check_for_pycache_in_gitignore, is_venv_ignored
 
 def test_if_gitignore_has_migrations():
     line = 'migrations/'
@@ -12,22 +16,34 @@ def test_if_gitignore_doesnt_have_migrations():
     errors = check_for_migrations_in_gitignore(line)
     assert errors == False
 
+@pytest.fixture
+def git_repo(tmp_path: Path):
+    subprocess.run(["git", "init", str(tmp_path)])
+    return tmp_path
 
-def test_if_venv_is_ignored():
-    line = 'venv/'
-    errors = check_for_venv_in_gitignore(['venv'], line)
-    assert errors == True
+def test_is_venv_ignored_external_to_project(git_repo: Path):
+    assert is_venv_ignored(git_repo) is True
 
-def test_if_venv_in_multiple_parts_is_ignored():
-    line = '.direnv'
-    errors = check_for_venv_in_gitignore(['.direnv', 'python-3.10'], line)
-    assert errors == True
+@pytest.mark.parametrize('ignored', [True, False])
+def test_is_venv_ignored_internal_to_project(monkeypatch, git_repo: Path, ignored: bool):
+    (git_repo / "a-fake-venv").mkdir()
 
-def test_if_venv_is_not_ignored():
-    line = ''
-    errors = check_for_venv_in_gitignore(['venv'],line)
-    assert errors == False
+    if ignored:
+        (git_repo / ".gitignore").write_text("a-fake-venv/")
 
+    monkeypatch.setattr(sys, 'prefix', str(git_repo / "a-fake-venv"))
+
+    assert is_venv_ignored(git_repo) is ignored
+
+def test_is_venv_ignored_missing_git(monkeypatch, git_repo: Path):
+    def mock_git_check_ignore(*args, **kwargs):
+        raise FileNotFoundError
+
+    # set the venv path inside the git repo so it tries to use git
+    monkeypatch.setattr(sys, 'prefix', str(git_repo / "a-fake-venv"))
+    monkeypatch.setattr(subprocess, 'run', mock_git_check_ignore)
+
+    assert is_venv_ignored(git_repo) is None
 
 def test_if_pycache_is_ignored_or_not():
     line = '__pycache__'


### PR DESCRIPTION
This includes the changes in #38.
Fixes #37.

I took a stab at improving the reliability of gitignore validation particularly for virtual environments. This uses git check-ignore to query git for what's ignored. I removed all of the VIRTUAL_ENV handling from gitignore checks since it's less robust than using `sys.prefix` (see also #36 which ran into this problem). I also added some tests to verify the behavior, though I don't have access to a Windows environment to test there.

Ideally I think this feature ought to be removed entirely because:
1. Virtualenv configuration is highly idiosyncratic with countless tools out there for managing the creation and invocation of them (e.g. sometimes activating them, sometimes directly invoking them). This sort of feature seems ripe for edge cases.
2. What is ignored seems difficult to accurately ascertain. git check-ignore is probably the best approach, but I'm not sure how it will interact with more exotic environments e.g. git worktrees, core git settings, etc.
3. This feature has already caused enough pain that at least 3 users have bothered to file issues about it: #28, #36, and #37.
4. Since there's scope creep here, it lends itself to extra confusion. It didn't occur to me that this would be an error message from django-fastdev. I initially suspected direnv but had to grep my entire virtualenv for "is not ignored in" before figuring it out.
5. It seems like this feature is *already* slated for removal in the future according to #33.

Gripes aside, this and #38 seemed to be the most straightforward way to get it to stop breaking my environment. Let me know what you think.
