### PR TITLE
Add support for ignoring templates that do live in the app's project

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -37,3 +37,7 @@ DATABASES = {
 }
 
 ROOT_URLCONF = 'tests.urls'
+
+FASTDEV_IGNORED_TEMPLATES = [
+    r".*.templates/ignored.*"
+]

--- a/tests/templates/ignored/test_resolve_simple.html
+++ b/tests/templates/ignored/test_resolve_simple.html
@@ -1,0 +1,1 @@
+{{ does_not_exist }}

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -168,3 +168,7 @@ def test_debug_engine(settings):
     settings.FASTDEV_STRICT_IF = True
     t = DEBUG_ENGINE.from_string('{% if does_not_exist %}{% endif %}{{ also_does_not_exist')
     t.render(Context())
+
+
+def test_ignored_templates():
+    render(req('get'), template_name='ignored/test_resolve_simple.html')


### PR DESCRIPTION
This fixes #40.

The main reason I want this is so that I can vendor upstream templates within my project. In particular, the ones from django-allauth-ui use slippers components, and the way slippers isolates the components' contexts is, when combined with a common usage pattern involving `|default`, incompatible with keeping django-fastdev active.

This is a quick attempt at the patch to make sure it was useful for me and that django-fastdev tests still pass with it applied.

Side note: most of the time spent  on this PR was spent trying to run the unit tests. My initial attempt at that was:

```
pip install -r requirements.txt
pip install -r test_requirements.txt
make test
```

That gave me errors related to hammett. It seems that the versions of django and pytest-django which are installed by those two commands are now incompatible with hammett. I spent a couple timeboxes trying to patch hammett to support the current version of pytest-django and made quite a bit of progress but gave up trying to support the now-required built-in MonkeyPatch fixtures. Let me know if you'd like to see how far I got, and I'm happy to share.

I wound up just using pytest like this from the project's root:

```
PYTHONPATH=. pytest
```

and all the tests, including the one I add in this PR, passed except for the 4 that were already decorated with `@pytest.mark.skip('Broken')`.

Let me know if there's anything more I should do to make it reasonable to merge this PR!
