### PR TITLE
Confirm a node actually has the child nodelist it claims to have before accessing the nodelist

### DIFF
--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -436,8 +436,9 @@ The object was: {current!r}
             else:
                 result = set()
             for child_nodelist_name in node.child_nodelists:
-                for x in getattr(node, child_nodelist_name):
-                    result |= collect_nested_blocks(x)
+                if hasattr(node, child_nodelist_name):
+                    for x in getattr(node, child_nodelist_name):
+                        result |= collect_nested_blocks(x)
             return result
 
         def get_extends_node_parent(extends_node, context):


### PR DESCRIPTION
Found that Django `IncludeNode.child_nodelists` is `('nodelists',)`, but the `IncludeNode` doesn't actually have a `nodelists` attribute. Check the attribute exists before accessing it. See https://github.com/boxed/django-fastdev/issues/47#issuecomment-2408610254.