### PR TITLE
feat(blocks): callback

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ FASTDEV_INVALID_BLOCKS_CALLBACK = "your_app.settings.fastdev_blocks"
 def fastdev_blocks(x, result):
     if hasattr(x, 'varname') and x.varname is not None:
         result.add(x.varname)
+        result.add(x.varname.replace('_', '-'))
     return result
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,19 @@ Django will silently throw away `hello!` because you wrote :code:`contents` inst
 of :code:`content`. :code:`django-fastdev` will turn this into an error which lists the
 invalid and valid block names in alphabetical order.
 
+You can customize the filter to understand also custom blocks in your `settings.py` file in this way (an example to integrate [Unfold](https://github.com/unfoldadmin/django-unfold)):
+
+settings.py:
+
+```
+FASTDEV_INVALID_BLOCKS_CALLBACK = "your_app.settings.fastdev_blocks"
+
+def fastdev_blocks(x, result):
+    if hasattr(x, 'varname') and x.varname is not None:
+        result.add(x.varname)
+    return result
+```
+
 Better error messages for reverse
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -451,6 +451,10 @@ The object was: {current!r}
         def collect_valid_blocks(template, context):
             result = set()
             for x in template.nodelist:
+                if getattr(settings, 'FASTDEV_INVALID_BLOCKS_CALLBACK', False) is not False:
+                    module, callback = settings.FASTDEV_INVALID_BLOCKS_CALLBACK.rsplit(".", 1)
+                    module = importlib.import_module(module)
+                    result = getattr(module, callback)(x, result)
                 if isinstance(x, ExtendsNode):
                     result |= collect_nested_blocks(x)
                     result |= collect_valid_blocks(get_extends_node_parent(x, context), context)
@@ -459,11 +463,6 @@ The object was: {current!r}
                     # 'isinstance(x, (AutoEscapeControlNode, BlockNode, FilterNode, ForNode, IfNode,
                     # IfChangedNode, SpacelessNode))' at the risk of missing some we don't know about
                     result |= collect_nested_blocks(x)
-                else:
-                    if getattr(settings, 'FASTDEV_INVALID_BLOCKS_CALLBACK', False) is False:
-                        module, callback = settings.FASTDEV_INVALID_BLOCKS_CALLBACK.rsplit(".", 1)
-                        module = importlib.import_module(module)
-                        result = getattr(module, callback)(x, result)
             return result
 
         orig_extends_render = ExtendsNode.render

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -4,6 +4,7 @@ import re
 import subprocess
 import sys
 import threading
+import importlib
 from functools import cache
 from typing import Optional
 import warnings
@@ -458,6 +459,11 @@ The object was: {current!r}
                     # 'isinstance(x, (AutoEscapeControlNode, BlockNode, FilterNode, ForNode, IfNode,
                     # IfChangedNode, SpacelessNode))' at the risk of missing some we don't know about
                     result |= collect_nested_blocks(x)
+                else:
+                    if settings.FASTDEV_INVALID_BLOCKS_CALLBACK is not None:
+                        module, callback = settings.FASTDEV_INVALID_BLOCKS_CALLBACK.rsplit(".", 1)
+                        module = importlib.import_module(module)
+                        result = getattr(module, callback)(x, result)
             return result
 
         orig_extends_render = ExtendsNode.render

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -460,7 +460,7 @@ The object was: {current!r}
                     # IfChangedNode, SpacelessNode))' at the risk of missing some we don't know about
                     result |= collect_nested_blocks(x)
                 else:
-                    if settings.FASTDEV_INVALID_BLOCKS_CALLBACK is not None:
+                    if getattr(settings, 'FASTDEV_INVALID_BLOCKS_CALLBACK', False) is False:
                         module, callback = settings.FASTDEV_INVALID_BLOCKS_CALLBACK.rsplit(".", 1)
                         module = importlib.import_module(module)
                         result = getattr(module, callback)(x, result)


### PR DESCRIPTION
Ref: https://github.com/boxed/django-fastdev/issues/51

So in my investigation I discovered that the issue is because Unfold register a custom node, `CaptureNode` so it isn't possible to detect what is the real block as it isn't a Django one.

With this code we are adding a new callback so the dev can implement a way to detect those blocks.
The readme include the code for Unfold theme as example.