### PR TITLE
constraint form clean methods validation to only forms within the project

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+1.14.0
+~~~~~~
+
+* Validation for Form clean() methods is now limited only to Forms existing within the project, and does not extend to third-party libraries
+
+
 1.13.0
 ~~~~~~
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,12 +1,6 @@
 Changelog
 ---------
 
-1.14.0
-~~~~~~
-
-* Validation for Form clean() methods is now limited only to Forms existing within the project, and does not extend to third-party libraries
-
-
 1.13.0
 ~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,11 @@ an error message telling you that your clean method doesn't match anything.
 This is also very useful during refactoring. Renaming a field is a lot safer
 as if you forget to rename the clean method :code:`django-fastdev` will tell you!
 
+By default, :code:`django-fastdev` will check only forms that exist within your project, 
+and not third-party libraries. If you would like to enable stricter validation that will 
+extend to ALL forms, you can set this by configuring :code:`FASTDEV_STRICT_FORM_CHECKING` 
+to :code:`True` in your Django settings.
+
 
 Faster startup
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -128,11 +128,6 @@ an error message telling you that your clean method doesn't match anything.
 This is also very useful during refactoring. Renaming a field is a lot safer
 as if you forget to rename the clean method :code:`django-fastdev` will tell you!
 
-By default, :code:`django-fastdev` will check only forms that exist within your project, 
-and not third-party libraries. If you would like to enable stricter validation that will 
-extend to ALL forms, you can set this by configuring :code:`FASTDEV_STRICT_FORM_CHECKING` 
-to :code:`True` in your Django settings.
-
 
 Faster startup
 ~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,11 @@ an error message telling you that your clean method doesn't match anything.
 This is also very useful during refactoring. Renaming a field is a lot safer
 as if you forget to rename the clean method :code:`django-fastdev` will tell you!
 
+By default, :code:`django-fastdev` will check only forms that exist within your project,
+and not third-party libraries. If you would like to enable stricter validation that will
+extend to ALL forms, you can set this by configuring :code:`FASTDEV_STRICT_FORM_CHECKING`
+to :code:`True` in your Django settings.
+
 
 Faster startup
 ~~~~~~~~~~~~~~

--- a/django_fastdev/__init__.py
+++ b/django_fastdev/__init__.py
@@ -1,12 +1,12 @@
-__version__ = "1.14.0"
+__version__ = '1.13.0'
 
 from threading import Thread
 from time import sleep
 
-default_app_config = "django_fastdev.apps.FastDevConfig"
+default_app_config = 'django_fastdev.apps.FastDevConfig'
 
 
-from django.core.management.commands.runserver import Command  # noqa: E402
+from django.core.management.commands.runserver import Command
 
 orig_check = Command.check
 orig_check_migrations = Command.check_migrations
@@ -16,7 +16,6 @@ def off_thread_check(self, *args, **kwargs):
     def inner():
         sleep(0.1)  # give the main thread some time to run
         orig_check(self, *args, **kwargs)
-
     t = Thread(target=inner)
     t.start()
 
@@ -25,7 +24,6 @@ def off_thread_check_migrations(self, *args, **kwargs):
     def inner():
         sleep(0.1)  # give the main thread some time to run
         orig_check_migrations(self, *args, **kwargs)
-
     t = Thread(target=inner)
     t.start()
 

--- a/django_fastdev/__init__.py
+++ b/django_fastdev/__init__.py
@@ -8,6 +8,8 @@ default_app_config = 'django_fastdev.apps.FastDevConfig'
 
 from django.core.management.commands.runserver import Command
 
+from .apps import fastdev_ignore  # noqa
+
 orig_check = Command.check
 orig_check_migrations = Command.check_migrations
 

--- a/django_fastdev/__init__.py
+++ b/django_fastdev/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.13.0'
+__version__ = '1.14.0'
 
 from threading import Thread
 from time import sleep

--- a/django_fastdev/__init__.py
+++ b/django_fastdev/__init__.py
@@ -1,12 +1,12 @@
-__version__ = '1.13.0'
+__version__ = "1.14.0"
 
 from threading import Thread
 from time import sleep
 
-default_app_config = 'django_fastdev.apps.FastDevConfig'
+default_app_config = "django_fastdev.apps.FastDevConfig"
 
 
-from django.core.management.commands.runserver import Command
+from django.core.management.commands.runserver import Command  # noqa: E402
 
 orig_check = Command.check
 orig_check_migrations = Command.check_migrations
@@ -16,6 +16,7 @@ def off_thread_check(self, *args, **kwargs):
     def inner():
         sleep(0.1)  # give the main thread some time to run
         orig_check(self, *args, **kwargs)
+
     t = Thread(target=inner)
     t.start()
 
@@ -24,6 +25,7 @@ def off_thread_check_migrations(self, *args, **kwargs):
     def inner():
         sleep(0.1)  # give the main thread some time to run
         orig_check_migrations(self, *args, **kwargs)
+
     t = Thread(target=inner)
     t.start()
 

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -250,12 +250,10 @@ def is_from_project(cls):
     ) and not module_path.startswith(venv_dir)
 
 
-def fastdev_ignore():
+def fastdev_ignore(target):
     """A decorator to exclude a function or class from fastdev checks."""
-    def decorator(target):
-        setattr(target, "fastdev_ignore", True)
-        return target
-    return decorator
+    setattr(target, "fastdev_ignore", True)
+    return target
 
 
 def get_venv_folder_name():
@@ -411,7 +409,7 @@ The object was: {current!r}
         def fastdev_full_clean(self):
             orig_form_full_clean(self)
             # check if class is from our project, or strict form checking is enabled
-            if is_from_project(type(self)) or strict_form_checking():
+            if is_from_project(type(self)) or strict_form_checking() and not getattr(self, 'fastdev_ignore', False):
                 from django.conf import settings
                 if settings.DEBUG:
                     prefix = 'clean_'

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -250,9 +250,9 @@ def is_from_project(cls):
 
     venv_dir = os.environ.get("VIRTUAL_ENV", "")
     module_path = os.path.abspath(module.__file__)
-    return module_path.startswith(str(settings.BASE_DIR)) or module_path.startswith(
-        venv_dir
-    )
+    return module_path.startswith(
+        str(settings.BASE_DIR)
+    ) and not module_path.startswith(venv_dir)
 
 
 def get_venv_folder_name():

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -5,33 +5,45 @@ import re
 import subprocess
 import sys
 import threading
-import warnings
-from contextlib import contextmanager, nullcontext
 from functools import cache
-from inspect import getmodule
-from pathlib import Path
 from typing import Optional
+import warnings
+from contextlib import (
+    contextmanager,
+    nullcontext,
+)
+from pathlib import Path
 
 from django.apps import AppConfig
 from django.conf import settings
-from django.db.models import Model, QuerySet
+from django.db.models import (
+    Model,
+    QuerySet,
+)
 from django.forms import Form
-from django.template import Context, engines
+from django.template import Context
 from django.template.base import (
     FilterExpression,
     TextNode,
-    TokenType,
     Variable,
     VariableDoesNotExist,
+    TokenType,
 )
-from django.template.defaulttags import ForNode  # noqa: F401
-from django.template.defaulttags import FirstOfNode, IfNode
-from django.template.loader_tags import BlockNode, ExtendsNode
-from django.template.loaders.app_directories import Loader as AppDirLoader
-from django.template.loaders.filesystem import Loader as FilesystemLoader
+from django.template.defaulttags import (
+    FirstOfNode,
+    IfNode,
+    ForNode
+)
+from django.template.loader_tags import (
+    BlockNode,
+    ExtendsNode,
+)
 from django.templatetags.i18n import BlockTranslateNode
 from django.urls.exceptions import NoReverseMatch
 from django.views.debug import DEBUG_ENGINE
+from django.template import engines
+from django.template.loaders.app_directories import Loader as AppDirLoader
+from django.template.loaders.filesystem import Loader as FilesystemLoader
 
 
 class FastDevVariableDoesNotExist(Exception):
@@ -71,9 +83,7 @@ def get_gitignore_path():
 
 
 def is_absolute_url(url):
-    return bool(
-        url.startswith("/") or url.startswith("http://") or url.startswith("https://")
-    )
+    return bool(url.startswith('/') or url.startswith('http://') or url.startswith('https://'))
 
 
 def validate_static_url_setting():
@@ -90,20 +100,17 @@ def validate_static_url_setting():
     Returns:
         None
     """
-    static_url = getattr(settings, "STATIC_URL", None)
+    static_url = getattr(settings, 'STATIC_URL', None)
 
     # check for static url
     if static_url and not is_absolute_url(static_url):
-        print(
-            f"""
+        print(f"""
         WARNING:
         You have STATIC_URL set to {static_url} in your settings.py file.
 
         It should start with either a '/' or 'http' to ensure it is an absolute URL.
 
-        """,
-            file=sys.stderr,
-        )
+        """, file=sys.stderr)
 
     return
 
@@ -122,15 +129,10 @@ def is_venv_ignored(project_path: Path) -> Optional[bool]:
     try:
         # ensure git is invoked as though it were run from the project directory, since
         # manage.py can be invoked from other directories.
-        check_ignore = subprocess.run(
-            ["git", "-C", project_path, "check-ignore", "--quiet", sys.prefix]
-        )
+        check_ignore = subprocess.run(["git", "-C", project_path, "check-ignore", "--quiet", sys.prefix])
         return check_ignore.returncode == 0
     except FileNotFoundError:
-        print(
-            "git is not installed. django-fastdev can't check if venv is ignored in .gitignore",
-            file=sys.stderr,
-        )
+        print("git is not installed. django-fastdev can't check if venv is ignored in .gitignore", file=sys.stderr)
         return None
 
 
@@ -145,43 +147,35 @@ def validate_gitignore(path):
     is_pycache_ignored = False
 
     with open(path, "r") as git_ignore_file:
-        for index, line in enumerate(git_ignore_file.readlines()):
+        for (index, line) in enumerate(git_ignore_file.readlines()):
+
             if check_for_migrations_in_gitignore(line):
-                bad_line_numbers_for_ignoring_migration.append(index + 1)
+                bad_line_numbers_for_ignoring_migration.append(index+1)
 
             if check_for_pycache_in_gitignore(line):
                 is_pycache_ignored = True
 
         if bad_line_numbers_for_ignoring_migration:
-            print(
-                f"""
+            print(f"""
             You have excluded migrations folders from git
 
             This is not a good idea! It's very important to commit all your migrations files into git for migrations to work properly.
 
             https://docs.djangoproject.com/en/dev/topics/migrations/#version-control for more information
 
-            Bad pattern on lines : {', '.join(map(str, bad_line_numbers_for_ignoring_migration))}""",
-                file=sys.stderr,
-            )
+            Bad pattern on lines : {', '.join(map(str, bad_line_numbers_for_ignoring_migration))}""", file=sys.stderr)
 
         if is_venv_ignored(project_path) is False:
-            print(
-                f"""
+            print(f"""
             {sys.prefix} is not ignored in .gitignore.
             Please add {sys.prefix} to .gitignore.
-            """,
-                file=sys.stderr,
-            )
+            """, file=sys.stderr)
 
         if not is_pycache_ignored and "__pycache__" in list_of_subfolders:
-            print(
-                """
+            print(f"""
             __pycache__ is not ignored in .gitignore.
             Please add __pycache__ to .gitignore.
-            """,
-                file=sys.stderr,
-            )
+            """, file=sys.stderr)
 
 
 def validate_fk_field(model):
@@ -215,44 +209,16 @@ def get_models_with_badly_named_pk():
             car = ForeignKey(Car)
 
         Django will create a `car_id` field under the hood that is the ID of that field (normally a number).""",
-            file=sys.stderr,
+            file=sys.stderr
         )
 
 
 def strict_if():
-    return getattr(settings, "FASTDEV_STRICT_IF", False)
+    return getattr(settings, 'FASTDEV_STRICT_IF', False)
 
 
 def strict_template_checking():
-    return getattr(settings, "FASTDEV_STRICT_TEMPLATE_CHECKING", False)
-
-
-def strict_form_checking():
-    return getattr(settings, "FASTDEV_STRICT_FORM_CHECKING", False)
-
-
-def is_from_project(cls):
-    """
-    Check if a class originates from the project directory.
-
-    Args:
-        cls: The class to check.
-        project_root: The root directory of your project (absolute path).
-
-    Returns:
-        bool: True if the class originates from the project directory, False otherwise.
-    """
-    module = getmodule(cls)
-
-    # check if built-in module or dynamically created class
-    if not module or not hasattr(module, "__file__"):
-        return False
-
-    venv_dir = os.environ.get("VIRTUAL_ENV", "")
-    module_path = os.path.abspath(module.__file__)
-    return module_path.startswith(
-        str(settings.BASE_DIR)
-    ) and not module_path.startswith(venv_dir)
+    return getattr(settings, 'FASTDEV_STRICT_TEMPLATE_CHECKING', False)
 
 
 def get_venv_folder_name():
@@ -265,7 +231,7 @@ def get_venv_folder_name():
 
 @cache
 def get_ignored_template_list():
-    ignored_templates_settings = getattr(settings, "FASTDEV_IGNORED_TEMPLATES", [])
+    ignored_templates_settings = getattr(settings, 'FASTDEV_IGNORED_TEMPLATES', [])
     ignored_templates = list()
     if ignored_templates_settings:
         for entry in ignored_templates_settings:
@@ -282,21 +248,15 @@ def template_is_ignored(origin_name):
 
 
 class FastDevConfig(AppConfig):
-    name = "django_fastdev"
-    verbose_name = "django-fastdev"
+    name = 'django_fastdev'
+    verbose_name = 'django-fastdev'
     default = True
 
     def ready(self):
         orig_resolve = FilterExpression.resolve
 
-        def resolve_override(
-            self, context, ignore_failures=False, ignore_failures_for_real=False
-        ):
-            if (
-                context.template_name is None
-                and "{% if exception_type %}{{ exception_type }}"
-                in context.template.source
-            ):
+        def resolve_override(self, context, ignore_failures=False, ignore_failures_for_real=False):
+            if context.template_name is None and '{% if exception_type %}{{ exception_type }}' in context.template.source:
                 # best guess we are in the 500 error page, do the default
                 return orig_resolve(self, context)
 
@@ -313,61 +273,49 @@ class FastDevConfig(AppConfig):
                     if not strict_template_checking():
                         # worry only about templates inside our project dir; if they
                         # exist elsewhere, then go to standard django behavior
-                        venv_dir = os.environ.get("VIRTUAL_ENV", "")
+                        venv_dir = os.environ.get('VIRTUAL_ENV', '')
                         origin = context.template.origin.name
                         if (
-                            origin != "<unknown source>"
-                            and "django-fastdev/tests/" not in origin
+                            origin != '<unknown source>' and
+                            'django-fastdev/tests/' not in origin
                             and (
                                 not origin.startswith(str(settings.BASE_DIR))
                                 or (venv_dir and origin.startswith(venv_dir))
                             )
                         ):
-                            return orig_resolve(
-                                self, context, ignore_failures=ignore_failures
-                            )
-                    if ignore_failures_for_real or getattr(
-                        _local, "ignore_errors", False
-                    ):
+                            return orig_resolve(self, context, ignore_failures=ignore_failures)
+                    if ignore_failures_for_real or getattr(_local, 'ignore_errors', False):
                         if _local.deprecation_warning:
-                            warnings.warn(
-                                _local.deprecation_warning, category=DeprecationWarning
-                            )
+                            warnings.warn(_local.deprecation_warning, category=DeprecationWarning)
                         return orig_resolve(self, context, ignore_failures=True)
 
                     if context.template.engine == DEBUG_ENGINE:
-                        return orig_resolve(
-                            self, context, ignore_failures=ignore_failures
-                        )
+                        return orig_resolve(self, context, ignore_failures=ignore_failures)
 
                     bit, current = e.params
                     if len(self.var.lookups) == 1:
-                        available = "\n    ".join(sorted(context.flatten().keys()))
-                        raise FastDevVariableDoesNotExist(f"""{self.var} does not exist in context. Available top level variables:
+                        available = '\n    '.join(sorted(context.flatten().keys()))
+                        raise FastDevVariableDoesNotExist(f'''{self.var} does not exist in context. Available top level variables:
 
     {available}
-""")
+''')
                     else:
-                        full_name = ".".join(self.var.lookups)
-                        extra = ""
+                        full_name = '.'.join(self.var.lookups)
+                        extra = ''
 
                         if isinstance(current, Context):
                             current = current.flatten()
 
                         if isinstance(current, dict):
-                            available_keys = "\n    ".join(sorted(current.keys()))
-                            extra = f"\nYou can access keys in the dict by their name. Available keys:\n\n    {available_keys}\n"
+                            available_keys = '\n    '.join(sorted(current.keys()))
+                            extra = f'\nYou can access keys in the dict by their name. Available keys:\n\n    {available_keys}\n'
                             error = f"dict does not have a key '{bit}', and does not have a member {bit}"
                         else:
-                            name = (
-                                f"{type(current).__module__}.{type(current).__name__}"
-                            )
-                            error = f"{name} does not have a member {bit}"
-                        available = "\n    ".join(
-                            sorted(x for x in dir(current) if not x.startswith("_"))
-                        )
+                            name = f'{type(current).__module__}.{type(current).__name__}'
+                            error = f'{name} does not have a member {bit}'
+                        available = '\n    '.join(sorted(x for x in dir(current) if not x.startswith('_')))
 
-                        raise FastDevVariableDoesNotExist(f"""Tried looking up {full_name} in context
+                        raise FastDevVariableDoesNotExist(f'''Tried looking up {full_name} in context
 
 {error}
 {extra}
@@ -376,7 +324,7 @@ Available attributes:
     {available}
 
 The object was: {current!r}
-""")
+''')
 
             return orig_resolve(self, context, ignore_failures)
 
@@ -396,14 +344,8 @@ The object was: {current!r}
             for condition, nodelist in self.conditions_nodelists:
                 if condition is not None:  # if / elif clause
                     context_handler = nullcontext()
-                    if (
-                        not strict_if()
-                        or "{% if exception_type %}{{ exception_type }}"
-                        in context.template.source
-                    ):
-                        context_handler = ignore_template_errors(
-                            deprecation_warning="set FASTDEV_STRICT_IF in settings, and use {% ifexists %} instead of {% if %} to check if a variable exists."
-                        )
+                    if not strict_if() or '{% if exception_type %}{{ exception_type }}' in context.template.source:
+                        context_handler = ignore_template_errors(deprecation_warning='set FASTDEV_STRICT_IF in settings, and use {% ifexists %} instead of {% if %} to check if a variable exists.')
 
                     with context_handler:
                         try:
@@ -416,16 +358,14 @@ The object was: {current!r}
                 if match:
                     return nodelist.render(context)
 
-            return ""
+            return ''
 
         IfNode.render = if_render_override
 
         # Better reverse() errors
         import django.urls.resolvers as res
-
         res.NoReverseMatch = FastDevNoReverseMatch
         import django.urls.base as bas
-
         bas.NoReverseMatch = FastDevNoReverseMatchNamespace
 
         # Forms validation
@@ -433,21 +373,14 @@ The object was: {current!r}
 
         def fastdev_full_clean(self):
             orig_form_full_clean(self)
-            # check if class is from our project, or strict form checking is enabled
-            if is_from_project(type(self)) or strict_form_checking():
-                from django.conf import settings
+            from django.conf import settings
+            if settings.DEBUG:
+                prefix = 'clean_'
+                for name in dir(self):
+                    if name.startswith(prefix) and callable(getattr(self, name)) and name[len(prefix):] not in self.fields:
+                        fields = '\n    '.join(sorted(self.fields.keys()))
 
-                if settings.DEBUG:
-                    prefix = "clean_"
-                    for name in dir(self):
-                        if (
-                            name.startswith(prefix)
-                            and callable(getattr(self, name))
-                            and name[len(prefix) :] not in self.fields
-                        ):
-                            fields = "\n    ".join(sorted(self.fields.keys()))
-
-                            raise InvalidCleanMethod(f"""Clean method {name} of class {self.__class__.__name__} won't apply to any field. Available fields:
+                        raise InvalidCleanMethod(f"""Clean method {name} of class {self.__class__.__name__} won't apply to any field. Available fields:
 
     {fields}""")
 
@@ -460,10 +393,10 @@ The object was: {current!r}
             assert len(e.args) == 1
             message = e.args[0]
             if args:
-                message += f"\n\nQuery args:\n\n    {args}"
+                message += f'\n\nQuery args:\n\n    {args}'
             if kwargs:
-                kwargs = "\n    ".join([f"{k}: {v!r}" for k, v in kwargs.items()])
-                message += f"\n\nQuery kwargs:\n\n    {kwargs}"
+                kwargs = '\n    '.join([f'{k}: {v!r}' for k, v in kwargs.items()])
+                message += f'\n\nQuery kwargs:\n\n    {kwargs}'
             e.args = (message,)
 
         def fast_dev_get(self, *args, **kwargs):
@@ -482,7 +415,7 @@ The object was: {current!r}
             # Gitignore validation
             git_ignore = get_gitignore_path()
             if git_ignore:
-                threading.Thread(target=validate_gitignore, args=(git_ignore,)).start()
+                threading.Thread(target=validate_gitignore, args=(git_ignore, )).start()
 
             # ForeignKey validation
             threading.Thread(target=get_models_with_badly_named_pk).start()
@@ -495,10 +428,8 @@ The object was: {current!r}
         def fastdev_render_token_list(self, tokens):
             for token in tokens:
                 if token.token_type == TokenType.VAR:
-                    if "." in token.contents:
-                        raise FastDevVariableDoesNotExist(
-                            "You can't use dotted paths in blocktrans. You must use {% with foo = something.bar %} around the blocktrans."
-                        )
+                    if '.' in token.contents:
+                        raise FastDevVariableDoesNotExist("You can't use dotted paths in blocktrans. You must use {% with foo = something.bar %} around the blocktrans.")
             return orig_blocktrans_render_token_list(self, tokens)
 
         BlockTranslateNode.render_token_list = fastdev_render_token_list
@@ -517,9 +448,7 @@ The object was: {current!r}
 
         def get_extends_node_parent(extends_node, context):
             compiled_parent = extends_node.get_parent(context)
-            del context.render_context[
-                extends_node.context_key
-            ]  # remove our history of doing this
+            del context.render_context[extends_node.context_key]  # remove our history of doing this
             return compiled_parent
 
         def collect_valid_blocks(template, context):
@@ -527,10 +456,8 @@ The object was: {current!r}
             for x in template.nodelist:
                 if isinstance(x, ExtendsNode):
                     result |= collect_nested_blocks(x)
-                    result |= collect_valid_blocks(
-                        get_extends_node_parent(x, context), context
-                    )
-                elif hasattr(x, "child_nodelists"):
+                    result |= collect_valid_blocks(get_extends_node_parent(x, context), context)
+                elif hasattr(x, 'child_nodelists'):
                     # to be more explicit, could make the condition above
                     # 'isinstance(x, (AutoEscapeControlNode, BlockNode, FilterNode, ForNode, IfNode,
                     # IfChangedNode, SpacelessNode))' at the risk of missing some we don't know about
@@ -541,29 +468,17 @@ The object was: {current!r}
 
         def extends_render(self, context):
             if settings.DEBUG:
-                valid_blocks = collect_valid_blocks(
-                    get_extends_node_parent(self, context), context
-                )
-                actual_blocks = {
-                    x.name for x in self.nodelist if isinstance(x, BlockNode)
-                }
+                valid_blocks = collect_valid_blocks(get_extends_node_parent(self, context), context)
+                actual_blocks = {x.name for x in self.nodelist if isinstance(x, BlockNode)}
                 invalid_blocks = actual_blocks - valid_blocks
                 if invalid_blocks:
-                    invalid_names = "    " + "\n    ".join(sorted(invalid_blocks))
-                    valid_names = "    " + "\n    ".join(sorted(valid_blocks))
-                    raise Exception(
-                        f"Invalid blocks specified:\n\n{invalid_names}\n\nValid blocks:\n\n{valid_names}"
-                    )
+                    invalid_names = '    ' + '\n    '.join(sorted(invalid_blocks))
+                    valid_names = '    ' + '\n    '.join(sorted(valid_blocks))
+                    raise Exception(f'Invalid blocks specified:\n\n{invalid_names}\n\nValid blocks:\n\n{valid_names}')
 
                 # Validate no thrown away (non-whitespace) text blocks
-                thrown_away_text = "\n    ".join(
-                    [
-                        repr(x.s.strip())
-                        for x in self.nodelist
-                        if isinstance(x, TextNode) and x.s.strip()
-                    ]
-                )
-                assert not thrown_away_text, f"The following html was thrown away when rendering {self.origin.template_name}:\n\n    {thrown_away_text}"
+                thrown_away_text = '\n    '.join([repr(x.s.strip()) for x in self.nodelist if isinstance(x, TextNode) and x.s.strip()])
+                assert not thrown_away_text, f'The following html was thrown away when rendering {self.origin.template_name}:\n\n    {thrown_away_text}'
 
             return orig_extends_render(self, context)
 
@@ -586,9 +501,7 @@ def get_template_files(directory):
     for root, _, files in os.walk(directory):
         for file in files:
             template_extensions = getattr(
-                settings,
-                "SHOWTEMPLATE_EXTENSIONS",
-                [".html", ".htm", ".django", ".jinja", ".md"],
+                settings, "SHOWTEMPLATE_EXTENSIONS", [".html", ".htm", ".django", ".jinja", ".md"]
             )
             if file.endswith(tuple(template_extensions)):
                 full_path = os.path.join(root, file)
@@ -661,12 +574,12 @@ def get_all_templates():
     return template_list
 
 
-from django.template import TemplateDoesNotExist  # noqa: E402
+from django.template import TemplateDoesNotExist
 
 
 def fastdev_template_does_not_exist_error(self):
     if not settings.DEBUG:
-        return "".join(self.args)
+        return ''.join(self.args)
 
     r = list(self.args)
 
@@ -674,13 +587,13 @@ def fastdev_template_does_not_exist_error(self):
 
     suggestions = difflib.get_close_matches(self.args[0], templates)
     if suggestions:
-        r += ["", "Did you mean?"]
-        r += [f"    {x}" for x in suggestions]
+        r += ['', 'Did you mean?']
+        r += [f'    {x}' for x in suggestions]
 
-    r += ["", "Valid values:"]
-    r += [f"    {x}" for x in templates]
+    r += ['', 'Valid values:']
+    r += [f'    {x}' for x in templates]
 
-    return "\n".join(r)
+    return '\n'.join(r)
 
 
 class InvalidCleanMethod(Exception):
@@ -688,36 +601,36 @@ class InvalidCleanMethod(Exception):
 
 
 class FastDevNoReverseMatchNamespace(NoReverseMatch):
+
     def __init__(self, msg):
         from django.conf import settings
-
         if settings.DEBUG:
             frame = inspect.currentframe().f_back
-            resolver = frame.f_locals["resolver"]
+            resolver = frame.f_locals['resolver']
 
-            msg += "\n\nAvailable namespaces:\n    "
-            msg += "\n    ".join(sorted(resolver.namespace_dict.keys()))
+            msg += '\n\nAvailable namespaces:\n    '
+            msg += '\n    '.join(sorted(resolver.namespace_dict.keys()))
 
         super().__init__(msg)
 
 
 class FastDevNoReverseMatch(NoReverseMatch):
+
     def __init__(self, msg):
         from django.conf import settings
-
         if settings.DEBUG:
             frame = inspect.currentframe().f_back
 
-            msg += "\n\nThese names exist:\n\n    "
+            msg += '\n\nThese names exist:\n\n    '
 
             names = []
 
-            resolver = frame.f_locals["self"]
+            resolver = frame.f_locals['self']
             for k in resolver.reverse_dict.keys():
                 if callable(k):
                     continue
                 names.append(k)
 
-            msg += "\n    ".join(sorted(names))
+            msg += '\n    '.join(sorted(names))
 
         super().__init__(msg)

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -248,8 +248,11 @@ def is_from_project(cls):
     if not module or not hasattr(module, "__file__"):
         return False
 
+    venv_dir = os.environ.get("VIRTUAL_ENV", "")
     module_path = os.path.abspath(module.__file__)
-    return module_path.startswith(os.path.abspath(settings.BASE_DIR))
+    return module_path.startswith(str(settings.BASE_DIR)) or module_path.startswith(
+        venv_dir
+    )
 
 
 def get_venv_folder_name():

--- a/django_fastdev/templatetags/fastdev.py
+++ b/django_fastdev/templatetags/fastdev.py
@@ -1,10 +1,7 @@
 from django import template
+
 # noinspection PyProtectedMember
-from django.template import (
-    Node,
-    NodeList,
-    TemplateSyntaxError,
-)
+from django.template import Node, NodeList, TemplateSyntaxError
 from django.template.defaulttags import TemplateIfParser
 
 from django_fastdev.apps import FastDevVariableDoesNotExist
@@ -13,12 +10,11 @@ register = template.Library()
 
 
 class IfExistsNode(Node):
-
     def __init__(self, conditions_nodelists):
         self.conditions_nodelists = conditions_nodelists
 
     def __repr__(self):
-        return '<%s>' % self.__class__.__name__
+        return "<%s>" % self.__class__.__name__
 
     def __iter__(self):
         for _, nodelist in self.conditions_nodelists:
@@ -30,20 +26,19 @@ class IfExistsNode(Node):
 
     def render(self, context):
         for condition, nodelist in self.conditions_nodelists:
-
-            if condition is not None:           # ifexists / elifexists clause
+            if condition is not None:  # ifexists / elifexists clause
                 try:
                     condition.eval(context)
                     match = True
                 except FastDevVariableDoesNotExist:
                     match = False
-            else:                               # else clause
+            else:  # else clause
                 match = True
 
             if match:
                 return nodelist.render(context)
 
-        return ''
+        return ""
 
 
 @register.tag
@@ -51,26 +46,30 @@ def ifexists(parser, token):
     # {% ifexists ... %}
     bits = token.split_contents()[1:]
     condition = TemplateIfParser(parser, bits).parse()
-    nodelist = parser.parse(('elifexists', 'else', 'endifexists'))
+    nodelist = parser.parse(("elifexists", "else", "endifexists"))
     conditions_nodelists = [(condition, nodelist)]
     token = parser.next_token()
 
     # {% elifexists ... %} (repeatable)
-    while token.contents.startswith('elifexists'):
+    while token.contents.startswith("elifexists"):
         bits = token.split_contents()[1:]
         condition = TemplateIfParser(parser, bits).parse()
-        nodelist = parser.parse(('elifexists', 'else', 'endifexists'))
+        nodelist = parser.parse(("elifexists", "else", "endifexists"))
         conditions_nodelists.append((condition, nodelist))
         token = parser.next_token()
 
     # {% else %} (optional)
-    if token.contents == 'else':
-        nodelist = parser.parse(('endifexists',))
+    if token.contents == "else":
+        nodelist = parser.parse(("endifexists",))
         conditions_nodelists.append((None, nodelist))
         token = parser.next_token()
 
     # {% endif %}
-    if token.contents != 'endifexists':
-        raise TemplateSyntaxError('Malformed template tag at line {}: "{}"'.format(token.lineno, token.contents))
+    if token.contents != "endifexists":
+        raise TemplateSyntaxError(
+            'Malformed template tag at line {}: "{}"'.format(
+                token.lineno, token.contents
+            )
+        )
 
     return IfExistsNode(conditions_nodelists)

--- a/django_fastdev/templatetags/fastdev.py
+++ b/django_fastdev/templatetags/fastdev.py
@@ -1,7 +1,10 @@
 from django import template
-
 # noinspection PyProtectedMember
-from django.template import Node, NodeList, TemplateSyntaxError
+from django.template import (
+    Node,
+    NodeList,
+    TemplateSyntaxError,
+)
 from django.template.defaulttags import TemplateIfParser
 
 from django_fastdev.apps import FastDevVariableDoesNotExist
@@ -10,11 +13,12 @@ register = template.Library()
 
 
 class IfExistsNode(Node):
+
     def __init__(self, conditions_nodelists):
         self.conditions_nodelists = conditions_nodelists
 
     def __repr__(self):
-        return "<%s>" % self.__class__.__name__
+        return '<%s>' % self.__class__.__name__
 
     def __iter__(self):
         for _, nodelist in self.conditions_nodelists:
@@ -26,19 +30,20 @@ class IfExistsNode(Node):
 
     def render(self, context):
         for condition, nodelist in self.conditions_nodelists:
-            if condition is not None:  # ifexists / elifexists clause
+
+            if condition is not None:           # ifexists / elifexists clause
                 try:
                     condition.eval(context)
                     match = True
                 except FastDevVariableDoesNotExist:
                     match = False
-            else:  # else clause
+            else:                               # else clause
                 match = True
 
             if match:
                 return nodelist.render(context)
 
-        return ""
+        return ''
 
 
 @register.tag
@@ -46,30 +51,26 @@ def ifexists(parser, token):
     # {% ifexists ... %}
     bits = token.split_contents()[1:]
     condition = TemplateIfParser(parser, bits).parse()
-    nodelist = parser.parse(("elifexists", "else", "endifexists"))
+    nodelist = parser.parse(('elifexists', 'else', 'endifexists'))
     conditions_nodelists = [(condition, nodelist)]
     token = parser.next_token()
 
     # {% elifexists ... %} (repeatable)
-    while token.contents.startswith("elifexists"):
+    while token.contents.startswith('elifexists'):
         bits = token.split_contents()[1:]
         condition = TemplateIfParser(parser, bits).parse()
-        nodelist = parser.parse(("elifexists", "else", "endifexists"))
+        nodelist = parser.parse(('elifexists', 'else', 'endifexists'))
         conditions_nodelists.append((condition, nodelist))
         token = parser.next_token()
 
     # {% else %} (optional)
-    if token.contents == "else":
-        nodelist = parser.parse(("endifexists",))
+    if token.contents == 'else':
+        nodelist = parser.parse(('endifexists',))
         conditions_nodelists.append((None, nodelist))
         token = parser.next_token()
 
     # {% endif %}
-    if token.contents != "endifexists":
-        raise TemplateSyntaxError(
-            'Malformed template tag at line {}: "{}"'.format(
-                token.lineno, token.contents
-            )
-        )
+    if token.contents != 'endifexists':
+        raise TemplateSyntaxError('Malformed template tag at line {}: "{}"'.format(token.lineno, token.contents))
 
     return IfExistsNode(conditions_nodelists)

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -35,7 +35,7 @@ def test_field_clean_validation(settings):
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
-    assert str(e.value) == """Clean method clean_field of class MyForm won't apply to any field. Available fields:\n\n    field"""
+    assert str(e.value) == """Clean method clean_flield of class MyForm won't apply to any field. Available fields:\n\n    field"""
 
 
 # noinspection PyStatementEffect
@@ -62,4 +62,4 @@ def test_field_clean_validation2(settings):
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
-    assert str(e.value) == """Clean method clean_field of class MyForm won't apply to any field. Available fields:\n\n    field"""
+    assert str(e.value) == """Clean method clean_flield of class MyForm won't apply to any field. Available fields:\n\n    field"""

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -9,6 +9,7 @@ from django_fastdev.apps import InvalidCleanMethod
 
 def test_ok_form_works(settings):
     settings.DEBUG = True
+    settings.FASTDEV_STRICT_FORM_CHECKING = True
 
     class MyForm(Form):
         field = CharField()

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -30,10 +30,12 @@ def test_field_clean_validation(settings):
     MyForm().errors
 
     settings.DEBUG = True
+    # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
+    settings.FASTDEV_STRICT_FORM_CHECKING = True
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
-    assert str(e.value) == """Clean method clean_flield of class MyForm won't apply to any field. Available fields:\n\n    field"""
+    assert str(e.value) == """Clean method clean_field of class MyForm won't apply to any field. Available fields:\n\n    field"""
 
 
 # noinspection PyStatementEffect
@@ -55,7 +57,9 @@ def test_field_clean_validation2(settings):
     MyForm().errors
 
     settings.DEBUG = True
+    # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
+    settings.FASTDEV_STRICT_FORM_CHECKING = True
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
-    assert str(e.value) == """Clean method clean_flield of class MyForm won't apply to any field. Available fields:\n\n    field"""
+    assert str(e.value) == """Clean method clean_field of class MyForm won't apply to any field. Available fields:\n\n    field"""

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -9,7 +9,6 @@ from django_fastdev.apps import InvalidCleanMethod
 
 def test_ok_form_works(settings):
     settings.DEBUG = True
-    settings.FASTDEV_STRICT_FORM_CHECKING = True
 
     class MyForm(Form):
         field = CharField()
@@ -31,7 +30,6 @@ def test_field_clean_validation(settings):
     MyForm().errors
 
     settings.DEBUG = True
-    settings.FASTDEV_STRICT_FORM_CHECKING = True  # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
@@ -57,7 +55,6 @@ def test_field_clean_validation2(settings):
     MyForm().errors
 
     settings.DEBUG = True
-    settings.FASTDEV_STRICT_FORM_CHECKING = True  # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -30,6 +30,7 @@ def test_field_clean_validation(settings):
     MyForm().errors
 
     settings.DEBUG = True
+    settings.FASTDEV_STRICT_FORM_CHECKING = True  # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
@@ -55,6 +56,7 @@ def test_field_clean_validation2(settings):
     MyForm().errors
 
     settings.DEBUG = True
+    settings.FASTDEV_STRICT_FORM_CHECKING = True  # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 


### PR DESCRIPTION
this modification constrains the default behavior for checking Form classes' clean methods to only those forms that exist within the project. forms which would fail this test but exist in third-party libraries are ignored. I added a configuration to enable strict validation if one would desire it.

a practical use case is django-oscar, which does indeed contain a form that fails the form clean validity check, thus breaking the project through third-party code, which is something we probably want to avoid.

ps: don't hate me but I reformatted with isort and ruff/black. it seemed nice to do ;(