### PR TITLE
bug fix: last pr had issue if venv wasn't being utilized

### DIFF
--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -104,40 +104,33 @@ def get_venv_path():
         return sys.prefix
 
     # 4. look for `pyvenv.cfg` in parent directories of `sys.executable`
+    def find_pyvenv_cfg(start_path):
+        """
+        Recursively search for `pyvenv.cfg` in the given directory and its parents.
+
+        Args:
+            start_path (str): The directory to start searching from.
+
+        Returns:
+            str or None: The path to `pyvenv.cfg` if found, or None otherwise.
+        """
+        current_path = start_path
+        while True:
+            potential_cfg = os.path.join(current_path, "pyvenv.cfg")
+            if os.path.isfile(potential_cfg):
+                return potential_cfg
+            parent_path = os.path.dirname(current_path)
+            if parent_path == current_path:
+                break
+            current_path = parent_path
+        return None
+
     venv_cfg_path = find_pyvenv_cfg(os.path.dirname(sys.executable))
     if venv_cfg_path:
         return os.path.dirname(venv_cfg_path)
 
     # if all else fails, return None
     return None
-
-
-def find_pyvenv_cfg(start_path):
-    """
-    Recursively search for `pyvenv.cfg` in the given directory and its parents.
-
-    Args:
-        start_path (str): The directory to start searching from.
-
-    Returns:
-        str or None: The path to `pyvenv.cfg` if found, or None otherwise.
-    """
-    current_path = start_path
-    while True:
-        potential_cfg = os.path.join(current_path, "pyvenv.cfg")
-        if os.path.isfile(potential_cfg):
-            return potential_cfg
-        parent_path = os.path.dirname(current_path)
-        if parent_path == current_path:
-            break
-        current_path = parent_path
-    return None
-
-
-
-def get_venv_folder_name():
-    venv_path = get_venv_path()
-    return os.path.basename(venv_path) if venv_path else venv_path
 
 
 def is_absolute_url(url):

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -254,9 +254,13 @@ def is_from_project(cls):
     venv_dir = get_venv_path()
     project_dir = get_path_for_django_project()
     module_path = os.path.abspath(module.__file__)
-    return module_path.startswith(str(project_dir)) and not (
-        bool(venv_dir) and module_path.startswith(venv_dir)
-    )
+
+    if module_path.startswith(project_dir):
+        # check against venv after project dir matches,
+        # just in case venv resides in project dir
+        if venv_dir and module_path.startswith(venv_dir):
+            return False
+        return True
 
 
 def fastdev_ignore(target):

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -255,10 +255,10 @@ def is_from_project(cls):
     project_dir = get_path_for_django_project()
     module_path = os.path.abspath(module.__file__)
 
-    if module_path.startswith(project_dir):
+    if module_path.startswith(str(project_dir)):
         # check against venv after project dir matches,
         # just in case venv resides in project dir
-        if venv_dir and module_path.startswith(venv_dir):
+        if venv_dir and module_path.startswith(str(venv_dir)):
             return False
         return True
 
@@ -321,7 +321,7 @@ class FastDevConfig(AppConfig):
                             and 'django-fastdev/tests/' not in origin
                             and (
                                 not origin.startswith(str(project_dir))
-                                or (bool(venv_dir) and origin.startswith(venv_dir))
+                                or (bool(venv_dir) and origin.startswith(str(venv_dir)))
                             )
                         ):
                             return orig_resolve(self, context, ignore_failures=ignore_failures)

--- a/django_fastdev/apps.py
+++ b/django_fastdev/apps.py
@@ -247,20 +247,23 @@ def is_from_project(cls):
     """
     module = getmodule(cls)
 
-    # check if built-in module or dynamically created class
+    # exit early if the module is built-in or dynamically created
     if not module or not hasattr(module, "__file__"):
         return False
 
-    venv_dir = get_venv_path()
-    project_dir = get_path_for_django_project()
     module_path = os.path.abspath(module.__file__)
+    project_dir = get_path_for_django_project()
+    venv_dir = get_venv_path()
 
-    if module_path.startswith(str(project_dir)):
-        # check against venv after project dir matches,
-        # just in case venv resides in project dir
-        if venv_dir and module_path.startswith(str(venv_dir)):
-            return False
-        return True
+    # check if the module belongs to the project directory
+    if not module_path.startswith(str(project_dir)):
+        return False
+
+    # exclude modules from the virtual environment if applicable
+    if venv_dir and module_path.startswith(str(venv_dir)):
+        return False
+
+    return True
 
 
 def fastdev_ignore(target):

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -1,0 +1,8 @@
+from django import forms
+
+
+class IgnoredForm(forms.Form):
+	my_field = forms.CharField()
+	
+	def clean_nonexistent_field(self):
+		pass

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -4,7 +4,7 @@ from django.forms import (
     Form,
 )
 
-from django_fastdev.apps import InvalidCleanMethod
+from django_fastdev.apps import InvalidCleanMethod, fastdev_ignore
 
 
 def test_ok_form_works(settings):
@@ -30,7 +30,7 @@ def test_field_clean_validation(settings):
     MyForm().errors
 
     settings.DEBUG = True
-    # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
+    # set strict mode otherwise test will fail (because dynamically typed form; doesn't have module.__file__ attribute)
     settings.FASTDEV_STRICT_FORM_CHECKING = True
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
@@ -57,9 +57,22 @@ def test_field_clean_validation2(settings):
     MyForm().errors
 
     settings.DEBUG = True
-    # set strict mode otherwise test will fail (because dynamically type form; doesn't exist in module)
+    # set strict mode otherwise test will fail (because dynamically typed form; doesn't have module.__file__ attribute)
     settings.FASTDEV_STRICT_FORM_CHECKING = True
     with pytest.raises(InvalidCleanMethod) as e:
         MyForm().errors
 
     assert str(e.value) == """Clean method clean_flield of class MyForm won't apply to any field. Available fields:\n\n    field"""
+
+
+def test_ignored_form_works(settings):
+    from .forms import IgnoredForm
+
+    IgnoredForm().errors
+
+    settings.DEBUG = True
+    with pytest.raises(InvalidCleanMethod) as e:
+        IgnoredForm().errors
+
+    IgnoredForm = fastdev_ignore(IgnoredForm)
+    IgnoredForm().errors


### PR DESCRIPTION
I am sorry my friend! I found a bug in my code from my previous pr. if one wasn't using a venv (and using python at root level instead), the check against project dir would always fail. additionally, I made a mistake in the if statement that checked whether or not a form should be verified (I should have grouped the or operand). this pr fixes these errors. forgive my mistakes! :(